### PR TITLE
relative imports of psi3d and gotm

### DIFF
--- a/Compiler.sh
+++ b/Compiler.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 export FORTRAN_COMPILER=IFORT
-export SI3DDIR=/mnt/c/Users/SV/Documents/GitHub/psi3d
-export GOTMDIR=/mnt/c/Users/SV/Documents/GitHub/gotm
+export SI3DDIR=../psi3d
+export GOTMDIR=../gotm
 #export SI3DDIR=/home/sv/GitHub/psi3d
 #export GOTMDIR=/home/sv/GitHub/gotm
 export MODDIR=$GOTMDIR/modules
@@ -11,7 +11,7 @@ export BINDIR=$GOTMDIR/bin
 export LIBDIR=$GOTMDIR/lib
 
 #IF IFGOTM=false --> The modules 'util' and 'turbulence' are not compiled
-export IFGOTM=true
+export IFGOTM=false
 #IF IFSI3D=false --> Only SI3D is compiled
 export IFSI3D=true
 

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@ all:
 	mpif90 -qopenmp -module $(MODDIR) -I/$(INCDIR) nspcg.f PlumeModels.f si3d_types.f90 si3d_ecomod.f90 si3d_utils.f90 si3d_boundaryconditions.f90 si3d_mixing.f90 si3d_procedures.f90 si3d.f90 -c
 	mpif90 -qopenmp -o psi3d *.o -module $(MODDIR) -I/$(INCDIR) -L/$(LIBDIR) -lturbulence_prod -lutil_prod
 omp:
-	ifort -qopenmp -qopenmp-link=static -module $(MODDIR) -I/$(INCDIR) nspcg.f PlumeModels.f si3d_types.f90 si3d_ecomod.f90 si3d_utils.f90 si3d_boundaryconditions.f90 si3d_mixing.f90 si3d_procedures.f90 si3d.f90 -c
-	ifort -qopenmp -qopenmp-link=static -o psi3d *.o -module $(MODDIR) -I/$(INCDIR) -L/$(LIBDIR) -lturbulence_prod -lutil_prod
+	ifort -qopenmp -qopenmp-link=static -module $(MODDIR) -I$(INCDIR) nspcg.f PlumeModels.f si3d_types.f90 si3d_ecomod.f90 si3d_utils.f90 si3d_boundaryconditions.f90 si3d_mixing.f90 si3d_procedures.f90 si3d.f90 -c
+	ifort -qopenmp -qopenmp-link=static -o psi3d *.o -module $(MODDIR) -I$(INCDIR) -L$(LIBDIR) -lturbulence_prod -lutil_prod
 sec:
 	ifort -qopenmp -module $(MODDIR) -I/$(INCDIR) nspcg.f PlumeModels.f si3d_types.f90 si3d_ecomod.f90 si3d_boundaryconditions.f90 si3d_mixing.f90 si3d_procedures.f90 si3d.f90 -c -O2
 	ifort -qopenmp -o psi3d *.o -module $(MODDIR) -I/$(INCDIR) -L/$(LIBDIR) -lturbulence_prod -lutil_prod -O2


### PR DESCRIPTION
- switch from hard-coded to relative imports of psi3d and gotm paths
-  fix `omp` recipe in `makefile` to accommodate relative imports
- Set default to `IFGOTM=false` in `Compiler.sh` (this does not completely remove gotm dependency for compilation though)