### PR TITLE
Fix of export of sed_h thickness.

### DIFF
--- a/si3d_ecomod.f90
+++ b/si3d_ecomod.f90
@@ -716,21 +716,22 @@ SUBROUTINE WQinput
     print*, 'ATM_NH4 = ', ATM_NH4, 'ATM_NO3 = ', ATM_NO3, 'ATM_PO4 = ', ATM_NO3
     print*, 'SED_DOC = ', SED_DOC, 'SED_DON = ', SED_DON, 'SED_DOP = ', SED_DOP
     print*, 'SED_NH4 = ', SED_NH4, 'SED_NO3 = ', SED_NO3, 'SED_PO4 = ', SED_PO4
-    PRINT*, 'sed_diam',sed_diameter
-    PRINT*,'sed_dens',sed_dens
-    PRINT*,'sed_frac',sed_frac
-    PRINT*, 'sed_type',sed_type
+    PRINT*, 'sed_h = ', sed_h
+    PRINT*, 'sed_diam = ',sed_diameter
+    PRINT*,'sed_dens = ',sed_dens
+    PRINT*,'sed_frac = ',sed_frac
+    PRINT*, 'sed_type = ',sed_type
     PRINT*,'kws = ',kws
-    print*,'kw21',kw21
-    print*,'atm_HgII',atm_HgII
-    print*,'kw23',kw23
-    print*,'ks23',ks23
-    print*,'KDO',KDO
-    print*,'DGMra',DGMra
-    print*,'k_Hg0w',k_Hg0w
-    print*,'k_Hg0atm',k_Hg0atm
-    print*,'Hg0atm',Hg0atm
-    print*,'K_H_Hg0w',K_H_Hg0w
+    print*,'kw21 = ',kw21
+    print*,'atm_HgII = ',atm_HgII
+    print*,'kw23 = ',kw23
+    print*,'ks23 = ',ks23
+    print*,'KDO = ',KDO
+    print*,'DGMra = ',DGMra
+    print*,'k_Hg0w = ',k_Hg0w
+    print*,'k_Hg0atm = ',k_Hg0atm
+    print*,'Hg0atm = ',Hg0atm
+    print*,'K_H_Hg0w = ',K_H_Hg0w
 
   END IF
 

--- a/si3d_procedures.f90
+++ b/si3d_procedures.f90
@@ -520,7 +520,7 @@ SUBROUTINE fd(n,t_exmom2,t_matmom2,t_matcon2,Bhaxpp,Bhaypp,Bth,Bth1,Bstart,Bend,
   !$omp barrier
 
   !.....Solve for non-active scalar transport
-  IF (ntr      >  0 .AND. & niter    >  0 .AND. &  lastiter == 1 ) THEN
+  IF (ntr      >  0 .AND. niter >  0 .AND. lastiter == 1 ) THEN
     IF (ecomod <  0) THEN
       CALL srcsnk00
     ELSE IF (ecomod == 0) THEN

--- a/si3d_types.f90
+++ b/si3d_types.f90
@@ -417,7 +417,7 @@
    integer                              :: LSS1, LSS2, LSS3 !< integers that determine the index of the constituent within tracer matrix
    integer                              :: sedMax = 3       !< Max number of sediments to model
    integer                              :: sedNumber        !< Number of sediments to model
-   real                                 :: sed_h            !< [m] Sediment Layer thickness
+   real                                 :: sed_h = 0.5      !< [m] Sediment Layer thickness
    real, allocatable, dimension (:)     :: sed_diameter     !< (um) Sediment diameter D50 in micrometers
    real, allocatable, dimension (:)     :: sed_dens         !< (kg/m3) Sediment density
    real, allocatable, dimension (:)     :: sed_frac         !< Fraction of type of sediment in total suspended sediment

--- a/si3d_utils.f90
+++ b/si3d_utils.f90
@@ -1146,8 +1146,8 @@ SUBROUTINE outt(n,thrs)
           ENDDO
         ENDIF
         zlevel_export(k) = zlevel(k+1)
-        if (k == km1) then
-          zlevel_export(k) = zlevel(k) + ddz
+        if (k == kmz(l) + 1) then
+          zlevel_export(k) = zlevel(k) + sed_h
         end if
      END DO
 


### PR DESCRIPTION
si3d_ecomod.f90
1. Just edits in the format of printing values for debugging. si3d_procedures.f90
1. Fix the error of & that Alicia experienced in her compiler version. si3d.types.f90
1. Assigned a specific value for sed_h for exporting. This is so the variable initiates with a value for outputting results properly. si3d_utils.f90
1. modified the if statement so the zlevel_export variables add the sediment layer's thickness rather than the cell's constant thickness from the input file.